### PR TITLE
feat: collapse/expand schema editor panel with hover-reveal toggle

### DIFF
--- a/src/client/App.css
+++ b/src/client/App.css
@@ -14,12 +14,100 @@
 }
 
 .app-editor-panel {
-  width: 33.333%;
+  position: relative;
+  flex: 0 0 33.333%;
   min-width: 300px;
+  max-width: 50%;
   border-right: 1px solid #3e3e42;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  transition:
+    flex-basis 0.2s ease,
+    min-width 0.2s ease,
+    max-width 0.2s ease;
+}
+
+.app-editor-panel--collapsed {
+  flex: 0 0 44px;
+  min-width: 44px;
+  max-width: 44px;
+}
+
+/* Narrow hit area on the left edge; button stays hidden until hover (or focus). */
+.app-editor-panel-toggle-zone {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 16px;
+  z-index: 10;
+  pointer-events: auto;
+}
+
+.app-editor-panel--collapsed .app-editor-panel-toggle-zone {
+  width: 100%;
+}
+
+.app-editor-panel-toggle-btn {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 32px;
+  height: 44px;
+  padding: 0;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: #cccccc;
+  font-size: 14px;
+  cursor: pointer;
+  line-height: 1;
+  opacity: 0;
+  transition:
+    opacity 0.18s ease,
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.app-editor-panel-toggle-zone:hover .app-editor-panel-toggle-btn,
+.app-editor-panel-toggle-btn:focus-visible {
+  opacity: 1;
+  background: #252526;
+  border-color: #3e3e42;
+}
+
+.app-editor-panel-toggle-zone:hover .app-editor-panel-toggle-btn:hover {
+  background: #3c3c3c;
+  color: #ffffff;
+}
+
+/* Touch / coarse pointer: no hover — keep control visible */
+@media (hover: none), (pointer: coarse) {
+  .app-editor-panel-toggle-btn {
+    opacity: 1;
+    background: #252526;
+    border-color: #3e3e42;
+  }
+}
+
+.app-editor-panel-body {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.app-editor-panel--collapsed .app-editor-panel-body {
+  flex: 0 0 0;
+  width: 0;
+  min-width: 0;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
 }
 
 .app-canvas-panel {

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -50,6 +50,11 @@ function App() {
   const [showSQLEditor] = useState(true); // Can be toggled in future
   const [importText, setImportText] = useState<string | undefined>(undefined);
   const [editorText, setEditorText] = useState<string>(''); // Track current editor text for saving
+  const [uiState, setUiState] = useState(() => uiStore.getState());
+
+  useEffect(() => {
+    return uiStore.subscribe(setUiState);
+  }, []);
 
   // Initialize with empty diagram if none exists
   useEffect(() => {
@@ -263,15 +268,43 @@ function App() {
         />
         <div className="app-main">
           {showSQLEditor && (
-            <div className="app-editor-panel">
-              <SQLEditor
-                diagram={diagramStore.getDiagram()}
-                onDiagramChange={handleDiagramChangeFromSQL}
-                sqlDialect={sqlDialect}
-                onDialectChange={setSqlDialect}
-                initialText={importText}
-                onTextChange={setEditorText}
-              />
+            <div
+              className={
+                uiState.editorPanelCollapsed
+                  ? 'app-editor-panel app-editor-panel--collapsed'
+                  : 'app-editor-panel'
+              }
+            >
+              <div className="app-editor-panel-body" aria-hidden={uiState.editorPanelCollapsed}>
+                <SQLEditor
+                  diagram={diagramStore.getDiagram()}
+                  onDiagramChange={handleDiagramChangeFromSQL}
+                  sqlDialect={sqlDialect}
+                  onDialectChange={setSqlDialect}
+                  initialText={importText}
+                  onTextChange={setEditorText}
+                />
+              </div>
+              <div className="app-editor-panel-toggle-zone">
+                <button
+                  type="button"
+                  className="app-editor-panel-toggle-btn"
+                  onClick={() =>
+                    uiStore.setState({
+                      editorPanelCollapsed: !uiStore.getState().editorPanelCollapsed,
+                    })
+                  }
+                  aria-expanded={!uiState.editorPanelCollapsed}
+                  aria-label={
+                    uiState.editorPanelCollapsed ? 'Expand schema editor' : 'Collapse schema editor'
+                  }
+                  title={
+                    uiState.editorPanelCollapsed ? 'Expand schema editor' : 'Collapse schema editor'
+                  }
+                >
+                  {uiState.editorPanelCollapsed ? '▶' : '◀'}
+                </button>
+              </div>
             </div>
           )}
           <div className="app-canvas-panel">

--- a/src/client/state/store/uiStore.ts
+++ b/src/client/state/store/uiStore.ts
@@ -8,6 +8,8 @@ export interface UIState {
   panOffset: { x: number; y: number };
   showGrid: boolean;
   showSidebar: boolean;
+  /** When true, the SQL/DBML editor panel is collapsed to a narrow strip */
+  editorPanelCollapsed: boolean;
 }
 
 /**
@@ -31,6 +33,7 @@ export class UIStore {
     panOffset: { x: 0, y: 0 },
     showGrid: true,
     showSidebar: true,
+    editorPanelCollapsed: false,
   };
 
   private observers: Array<Observer<UIState>> = [];


### PR DESCRIPTION
# Summary
Adds a collapsible SQL/DBML editor panel so users can give more space to the canvas, with a control that stays hidden by default and appears when hovering the left edge of the panel. Touch / coarse-pointer devices show the control always so it remains tappable.

# What changed
* UIStore: new editorPanelCollapsed flag (default false).
* App: subscribes to uiStore for re-renders; wraps SQLEditor in a panel with an overlay toggle strip.
* Layout / CSS: editor panel is position: relative; toggle lives in an absolute strip on the left (narrow when expanded, full width when collapsed); button uses opacity + :hover / :focus-visible; media query for hover-none / coarse pointer keeps the button visible.
* SQLEditor: stays mounted when collapsed (hidden via CSS) so editor text is not lost.
# Testing
npm run type-check, npm run lint, npm run format:check, npm run build, and npm test were run successfully before pushing.
# Notes
A formal PR template can be added in a separate branch later; this description documents the current feature only.