### PR TITLE
Feature/improve rendering ux1

### DIFF
--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -5,6 +5,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
 TESTS=(
+  src/client/core/__tests__/test-auto-layout.ts
   src/client/core/__tests__/test-domain-models.ts
   src/client/core/__tests__/test-validators.ts
   src/server/__tests__/test-repositories.ts

--- a/src/client/__tests__/test-export-functionality.ts
+++ b/src/client/__tests__/test-export-functionality.ts
@@ -11,6 +11,7 @@ import { ExportService } from '../services/ExportService';
 import { ApiClient } from '../services/ApiClient';
 import { Diagram } from '../core/diagram/Diagram';
 import { Table } from '../core/table/Table';
+import { Relationship } from '../core/relationship/Relationship';
 import { FrontendExporter } from '../core/exporter/FrontendExporter';
 
 async function testExportDialogLogic(): Promise<void> {
@@ -340,6 +341,43 @@ async function testFrontendSvgMatchesCurrentErdStyle(): Promise<void> {
   console.log('✅ Frontend SVG style parity working');
 }
 
+async function testSvgExportReflectsMovedTablePositions(): Promise<void> {
+  console.log('\n🧪 Testing SVG export reflects moved table positions...');
+
+  const exporter = new FrontendExporter();
+  const diagram = Diagram.create('svg-move-test');
+  const ta = new Table('ta-move', 'users', { x: 0, y: 0 }, [
+    { id: 'ca', name: 'id', type: 'int', constraints: [{ type: 'PRIMARY_KEY' }] },
+  ]);
+  const tb = new Table('tb-move', 'posts', { x: 420, y: 0 }, [
+    { id: 'cb', name: 'id', type: 'int', constraints: [{ type: 'PRIMARY_KEY' }] },
+    { id: 'cbf', name: 'user_id', type: 'int', constraints: [{ type: 'FOREIGN_KEY' }] },
+  ]);
+  diagram.addTable(ta);
+  diagram.addTable(tb);
+  diagram.addRelationship(
+    new Relationship('r-move', tb.getId(), 'cbf', ta.getId(), 'ca', 'ONE_TO_MANY', false)
+  );
+
+  const before = exporter.exportSVG(diagram);
+  if (!before.success || !before.data) {
+    throw new Error('SVG export failed before move');
+  }
+
+  ta.moveTo({ x: 900, y: 120 });
+
+  const after = exporter.exportSVG(diagram);
+  if (!after.success || !after.data) {
+    throw new Error('SVG export failed after move');
+  }
+
+  if (before.data === after.data) {
+    throw new Error('SVG output should change after moving a table');
+  }
+
+  console.log('✅ SVG export reflects moved table positions');
+}
+
 async function runTests(): Promise<void> {
   try {
     await testExportDialogLogic();
@@ -350,6 +388,7 @@ async function runTests(): Promise<void> {
     await testExportIntegration();
     await testExportFormats();
     await testFrontendSvgMatchesCurrentErdStyle();
+    await testSvgExportReflectsMovedTablePositions();
 
     console.log('\n✅ All export functionality tests passed!');
   } catch (error) {

--- a/src/client/components/DiagramCanvas/DiagramCanvas.tsx
+++ b/src/client/components/DiagramCanvas/DiagramCanvas.tsx
@@ -284,10 +284,16 @@ export const DiagramCanvas: React.FC<DiagramCanvasProps> = ({
       if (animationFrameRef.current) {
         cancelAnimationFrame(animationFrameRef.current);
       }
+      // Persist table positions into the store as a new Diagram instance (JSON round-trip)
+      // so export/SVG and any listeners always see the latest x/y, not a stale snapshot.
+      const d = diagramStore.getDiagram();
+      if (d) {
+        diagramStore.setDiagram(Diagram.fromJSON(d.toJSON()));
+      }
       // Force final re-render to ensure relationship lines are updated
       setForceUpdate(prev => prev + 1);
     }
-  }, [draggedTableId]);
+  }, [draggedTableId, diagramStore]);
 
   // Document-level mouse move handler for continuous dragging
   useEffect(() => {

--- a/src/client/components/DiagramCanvas/DiagramContent.tsx
+++ b/src/client/components/DiagramCanvas/DiagramContent.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, memo } from 'react';
+import React, { useMemo } from 'react';
 import { Diagram } from '../../core/diagram/Diagram';
 import { TableNode } from '../TableNode/TableNode';
 import { RelationshipLine } from '../RelationshipLine/RelationshipLine';
@@ -43,9 +43,6 @@ const DiagramContentComponent: React.FC<DiagramContentProps> = ({
   //   [viewport, draggedTableId]
   // );
 
-  // Get tables and relationships - don't memoize to ensure re-render when positions change
-  // This ensures tables and relationships re-render when table positions update
-  const tables = diagram.getAllTables();
   const relationships = diagram.getAllRelationships();
 
   // Filter tables visible in viewport (with padding for smooth scrolling)
@@ -53,7 +50,7 @@ const DiagramContentComponent: React.FC<DiagramContentProps> = ({
   // TODO: Re-enable viewport filtering with proper bounds checking
   const visibleTables = useMemo(() => {
     // Show all tables for now to prevent disappearing issue
-    return tables;
+    return diagram.getAllTables();
 
     // Original viewport filtering code (disabled for debugging)
     // return tables.filter(table => {
@@ -72,7 +69,7 @@ const DiagramContentComponent: React.FC<DiagramContentProps> = ({
     //   // Use expanded viewport to include tables near the visible area
     //   return isInViewport(bounds, expandedViewport);
     // });
-  }, [tables]);
+  }, [diagram]);
 
   // Filter relationships - show all relationships if both tables exist
   // Temporarily disable viewport filtering for relationships to debug
@@ -175,16 +172,10 @@ const DiagramContentComponent: React.FC<DiagramContentProps> = ({
   );
 };
 
-// Memoize DiagramContent to prevent unnecessary re-renders
-export const DiagramContent = memo(DiagramContentComponent, (prevProps, nextProps) => {
-  // Only re-render if diagram, viewport, or selection changes
-  return (
-    prevProps.diagram === nextProps.diagram &&
-    prevProps.uiState.selectedTableId === nextProps.uiState.selectedTableId &&
-    prevProps.viewport.x === nextProps.viewport.x &&
-    prevProps.viewport.y === nextProps.viewport.y &&
-    prevProps.viewport.zoom === nextProps.viewport.zoom &&
-    prevProps.viewport.width === nextProps.viewport.width &&
-    prevProps.viewport.height === nextProps.viewport.height
-  );
-});
+/**
+ * Do not wrap in React.memo with reference equality on `diagram`: table positions are mutated
+ * on the same Diagram instance in some flows, and Auto layout replaces via fromJSON — both cases
+ * must re-render when positions change. Drag relies on forceUpdate key on the parent; layout
+ * must not depend on that.
+ */
+export const DiagramContent = DiagramContentComponent;

--- a/src/client/components/ExportDialog/ExportDialog.tsx
+++ b/src/client/components/ExportDialog/ExportDialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { ExportService } from '../../services/ExportService';
 import { DiagramStore } from '../../state/store/diagramStore';
+import { Diagram } from '../../core/diagram/Diagram';
 import { FrontendExporter } from '../../core/exporter/FrontendExporter';
 import './ExportDialog.css';
 
@@ -20,7 +21,7 @@ const SUPPORTED_FORMATS = [
 export const ExportDialog: React.FC<ExportDialogProps> = ({
   isOpen,
   onClose,
-  exportService,
+  exportService: _exportService,
   diagramStore,
 }) => {
   const [selectedFormat, setSelectedFormat] = useState<string>('json');
@@ -33,11 +34,13 @@ export const ExportDialog: React.FC<ExportDialogProps> = ({
   if (!isOpen) return null;
 
   const handleExport = async () => {
-    const diagram = diagramStore.getDiagram();
-    if (!diagram) {
+    const current = diagramStore.getDiagram();
+    if (!current) {
       setError('No diagram to export');
       return;
     }
+    // Deep snapshot from serialized state so positions (after drag) always match what we export
+    const diagram = Diagram.fromJSON(current.toJSON());
 
     setIsExporting(true);
     setExportProgress(0);
@@ -67,34 +70,36 @@ export const ExportDialog: React.FC<ExportDialogProps> = ({
           exportError = result.error;
         }
       } else if (selectedFormat === 'svg') {
-        const result = frontendExporter.exportSVG(diagram);
-        if (result.success) {
-          exportData = result.data;
+        // Wait for layout paint so .table-node boxes match the store (same source as RelationshipLine).
+        await new Promise<void>(resolve => {
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => resolve());
+          });
+        });
+        const latest = diagramStore.getDiagram();
+        if (!latest) {
+          exportError = 'No diagram to export';
         } else {
-          exportError = result.error;
+          const diagramForSvg = Diagram.fromJSON(latest.toJSON());
+          const result = frontendExporter.exportSVG(diagramForSvg);
+          if (result.success) {
+            exportData = result.data;
+          } else {
+            exportError = result.error;
+          }
         }
       }
 
       setExportProgress(75);
 
-      if (exportError || !exportData) {
-        // Fallback to backend export if diagram is saved
-        const diagramId = diagram.getId();
-        if (diagramId) {
-          const result = await exportService.exportDiagram(diagramId, selectedFormat);
-          if (!result.success) {
-            setError(result.error || exportError || 'Export failed');
-            setIsExporting(false);
-            setExportProgress(0);
-            return;
-          }
-          exportData = result.data as string;
-        } else {
-          setError(exportError || 'Export failed');
-          setIsExporting(false);
-          setExportProgress(0);
-          return;
-        }
+      if (exportError || exportData === undefined) {
+        // JSON / SQL / SVG are generated in-browser from the current diagram (including unsaved
+        // table positions after drag). Do not fall back to the server: that uses the last saved
+        // file and a simpler SVG renderer, so exports would not match the canvas.
+        setError(exportError || 'Export failed');
+        setIsExporting(false);
+        setExportProgress(0);
+        return;
       }
 
       setExportProgress(90);

--- a/src/client/components/RelationshipLine/RelationshipLine.tsx
+++ b/src/client/components/RelationshipLine/RelationshipLine.tsx
@@ -3,6 +3,12 @@ import { Relationship } from '../../core/relationship/Relationship';
 import { Table } from '../../core/table/Table';
 import './RelationshipLine.css';
 
+/** Match TableNode / FrontendExporter SVG: optional table description adds header height */
+function getTableHeaderHeightForRouting(table: Table): number {
+  const desc = table.getMetadata()?.description?.trim();
+  return desc ? 72 : 40;
+}
+
 interface RelationshipLineProps {
   relationship: Relationship;
   fromTable: Table;
@@ -38,7 +44,6 @@ const RelationshipLineComponent: React.FC<RelationshipLineProps> = ({
     // Fallback dimensions when DOM node isn't available yet
     const FALLBACK_TABLE_WIDTH = 200;
     const FALLBACK_TABLE_HEIGHT = 120;
-    const TABLE_HEADER_HEIGHT = 40;
     const COLUMN_HEIGHT = 30;
     // Ensure HORIZONTAL_OFFSET is large enough to prevent line from overlapping table
     // Minimum 40px to ensure line doesn't go through table even with markers
@@ -96,11 +101,13 @@ const RelationshipLineComponent: React.FC<RelationshipLineProps> = ({
       };
     }
 
+    const fromHeaderH = getTableHeaderHeightForRouting(fromTable);
+    const toHeaderH = getTableHeaderHeightForRouting(toTable);
+
     // Calculate Y position of the column (center of the column row)
     const fromColumnY =
-      fromPos.y + TABLE_HEADER_HEIGHT + fromColumnIndex * COLUMN_HEIGHT + COLUMN_HEIGHT / 2;
-    const toColumnY =
-      toPos.y + TABLE_HEADER_HEIGHT + toColumnIndex * COLUMN_HEIGHT + COLUMN_HEIGHT / 2;
+      fromPos.y + fromHeaderH + fromColumnIndex * COLUMN_HEIGHT + COLUMN_HEIGHT / 2;
+    const toColumnY = toPos.y + toHeaderH + toColumnIndex * COLUMN_HEIGHT + COLUMN_HEIGHT / 2;
 
     // Calculate table boundaries
     const fromLeft = fromPos.x;
@@ -180,7 +187,17 @@ const RelationshipLineComponent: React.FC<RelationshipLineProps> = ({
         endDirection: 'right' as const, // Marker points to the right (away from table)
       };
     }
-  }, [fromX, fromY, toX, toY, fromTable, toTable, relationship]);
+  }, [
+    fromX,
+    fromY,
+    toX,
+    toY,
+    fromTable,
+    toTable,
+    relationship,
+    fromTable.getMetadata()?.description,
+    toTable.getMetadata()?.description,
+  ]);
 
   // Memoize relationship type styling
   const lineStyle = useMemo(() => {

--- a/src/client/components/Toolbar/Toolbar.tsx
+++ b/src/client/components/Toolbar/Toolbar.tsx
@@ -3,6 +3,7 @@ import { DiagramService } from '../../services/DiagramService';
 import { ExportService } from '../../services/ExportService';
 import { DiagramStore } from '../../state/store/diagramStore';
 import { Diagram } from '../../core/diagram/Diagram';
+import { applyAutoLayout } from '../../core/diagram/autoLayoutDiagram';
 import { ImportDialog } from '../ImportDialog/ImportDialog';
 import { ExportDialog } from '../ExportDialog/ExportDialog';
 import { LoadDialog } from '../LoadDialog/LoadDialog';
@@ -73,6 +74,17 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     }
   };
 
+  const handleAutoLayout = () => {
+    const diagram = diagramStore.getDiagram();
+    if (!diagram || diagram.getAllTables().length === 0) {
+      return;
+    }
+    // Layout on a fresh clone so we never half-mutate the store’s diagram, then swap once.
+    const laidOut = Diagram.fromJSON(diagram.toJSON());
+    applyAutoLayout(laidOut);
+    diagramStore.setDiagram(laidOut);
+  };
+
   const handleImport = (diagram: Diagram, importText?: string) => {
     // Debug: Check relationships before setting diagram
     const relationshipsBefore = diagram.getAllRelationships();
@@ -111,6 +123,13 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           title="Load Diagram"
         >
           Load
+        </button>
+        <button
+          className="toolbar-button"
+          onClick={handleAutoLayout}
+          title="Arrange tables by relationship groups (FK graph)"
+        >
+          Auto layout
         </button>
       </div>
 

--- a/src/client/core/__tests__/test-auto-layout.ts
+++ b/src/client/core/__tests__/test-auto-layout.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for autoLayoutDiagram
+ * Run with: npx tsx src/client/core/__tests__/test-auto-layout.ts
+ */
+
+import { Diagram } from '../diagram/Diagram';
+import { Table } from '../table/Table';
+import { Relationship } from '../relationship/Relationship';
+import { applyAutoLayout } from '../diagram/autoLayoutDiagram';
+import type { Column } from '@/types/table.types';
+
+function col(id: string, name: string, type: string): Column {
+  return { id, name, type, constraints: [] };
+}
+
+async function testIsolatedTablesDoNotOverlap(): Promise<void> {
+  const d = Diagram.create('d1');
+  const a = new Table('t-a', 'A', { x: 0, y: 0 }, [col('c1', 'id', 'int')]);
+  const b = new Table('t-b', 'B', { x: 0, y: 0 }, [col('c2', 'id', 'int')]);
+  d.addTable(a);
+  d.addTable(b);
+  applyAutoLayout(d);
+  const pa = a.getPosition();
+  const pb = b.getPosition();
+  if (pa.x === pb.x && pa.y === pb.y) {
+    throw new Error('Isolated tables should not share the same position');
+  }
+  console.log('✅ Isolated tables spaced');
+}
+
+async function testChainLayersVertically(): Promise<void> {
+  const d = Diagram.create('d2');
+  const users = new Table('t-u', 'users', { x: 0, y: 0 }, [col('c1', 'id', 'int')]);
+  const posts = new Table('t-p', 'posts', { x: 0, y: 0 }, [
+    col('c1', 'id', 'int'),
+    col('c2', 'user_id', 'int'),
+  ]);
+  d.addTable(users);
+  d.addTable(posts);
+  d.addRelationship(
+    new Relationship('r1', posts.getId(), 'c2', users.getId(), 'c1', 'ONE_TO_MANY', false)
+  );
+  applyAutoLayout(d);
+  const yu = users.getPosition().y;
+  const yp = posts.getPosition().y;
+  if (yu === yp) {
+    throw new Error('Expected FK chain to use different Y layers');
+  }
+  console.log('✅ FK chain uses vertical layers');
+}
+
+async function run(): Promise<void> {
+  console.log('\n🧪 autoLayoutDiagram tests');
+  await testIsolatedTablesDoNotOverlap();
+  await testChainLayersVertically();
+  console.log('✅ autoLayoutDiagram tests passed');
+}
+
+run().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/client/core/diagram/autoLayoutDiagram.ts
+++ b/src/client/core/diagram/autoLayoutDiagram.ts
@@ -1,0 +1,287 @@
+import { Diagram } from './Diagram';
+import { Table } from '../table/Table';
+
+/** Horizontal gap between adjacent table bounding boxes */
+const H_GAP = 64;
+/** Vertical gap between layers / wrapped rows */
+const V_GAP = 56;
+const MIN_TABLE_WIDTH = 240;
+/** Must stay in sync with RelationshipLine COLUMN_HEIGHT (30) for stable edge anchors */
+const TABLE_HEADER_HEIGHT = 40;
+const COLUMN_ROW_HEIGHT = 30;
+/** Approximate average char width (px) for 12–14px UI font */
+const CHAR_W = 7.5;
+const TABLE_HPADDING = 52;
+/** If a layer row is wider than this, wrap to the next visual row */
+const MAX_LAYER_ROW_WIDTH = 1500;
+/** After this total width, start the next component block on a new row (reduces mile-long edges) */
+const MAX_COMPONENT_LINE_WIDTH = 2200;
+/** Space between disconnected graph components */
+const COMPONENT_GAP = 100;
+const MARGIN = 80;
+
+function estimateTableWidth(table: Table): number {
+  const meta = table.getMetadata();
+  let w = table.getName().length * CHAR_W + TABLE_HPADDING;
+
+  if (meta?.description && meta.description.trim()) {
+    const descLine = Math.min(30, meta.description.length);
+    w = Math.max(w, descLine * CHAR_W + TABLE_HPADDING);
+  }
+
+  for (const col of table.getAllColumns()) {
+    const mainChars = col.name.length + col.type.length + 6;
+    const commentChars = col.comment ? Math.min(28, col.comment.length) : 0;
+    const badgeW = (col.constraints?.length ?? 0) * 30;
+    const rowInner = mainChars * CHAR_W + commentChars * CHAR_W * 0.85 + badgeW;
+    w = Math.max(w, rowInner + TABLE_HPADDING);
+  }
+
+  // Generous upper bound — wide tables are common in real schemas; better overlap than underlap
+  return Math.min(1400, Math.max(MIN_TABLE_WIDTH, Math.ceil(w)));
+}
+
+function estimateTableHeight(table: Table): number {
+  const meta = table.getMetadata();
+  let h = TABLE_HEADER_HEIGHT;
+  if (meta?.description && meta.description.trim()) {
+    h += 40;
+  }
+  const cols = table.getAllColumns().length;
+  h += Math.max(1, cols) * COLUMN_ROW_HEIGHT + 16;
+  return h;
+}
+
+function estimateTableSize(table: Table): { w: number; h: number } {
+  return { w: estimateTableWidth(table), h: estimateTableHeight(table) };
+}
+
+function normalizeName(table: Table): string {
+  return table.getName().toLowerCase();
+}
+
+function getConnectedComponents(tableIds: string[], edges: Array<[string, string]>): string[][] {
+  const adj = new Map<string, Set<string>>();
+  for (const id of tableIds) {
+    adj.set(id, new Set());
+  }
+  for (const [a, b] of edges) {
+    adj.get(a)?.add(b);
+    adj.get(b)?.add(a);
+  }
+
+  const visited = new Set<string>();
+  const components: string[][] = [];
+
+  for (const id of tableIds) {
+    if (visited.has(id)) continue;
+    const comp: string[] = [];
+    const stack = [id];
+    visited.add(id);
+    while (stack.length) {
+      const u = stack.pop()!;
+      comp.push(u);
+      for (const v of adj.get(u) ?? []) {
+        if (!visited.has(v)) {
+          visited.add(v);
+          stack.push(v);
+        }
+      }
+    }
+    components.push(comp);
+  }
+  return components;
+}
+
+function bfsLayers(
+  root: string,
+  adj: Map<string, Set<string>>,
+  nodes: Set<string>
+): Map<string, number> {
+  const layer = new Map<string, number>();
+  const queue: string[] = [root];
+  layer.set(root, 0);
+
+  while (queue.length) {
+    const u = queue.shift()!;
+    const lu = layer.get(u) ?? 0;
+    for (const v of adj.get(u) ?? []) {
+      if (!nodes.has(v)) continue;
+      if (!layer.has(v)) {
+        layer.set(v, lu + 1);
+        queue.push(v);
+      }
+    }
+  }
+
+  for (const n of nodes) {
+    if (!layer.has(n)) {
+      layer.set(n, 0);
+    }
+  }
+  return layer;
+}
+
+/**
+ * Places tables in one logical layer, wrapping to additional rows when wider than MAX_LAYER_ROW_WIDTH.
+ * Coordinates are relative to the component's local origin (0,0).
+ */
+function placeLayerRowWrapped(
+  rowTableIds: string[],
+  startY: number,
+  leftMargin: number,
+  tableById: Map<string, Table>
+): { positions: Map<string, { x: number; y: number }>; nextY: number; maxRight: number } {
+  const positions = new Map<string, { x: number; y: number }>();
+  const maxX = leftMargin + MAX_LAYER_ROW_WIDTH;
+
+  let x = leftMargin;
+  let y = startY;
+  let rowMaxH = 0;
+  let maxRight = leftMargin;
+
+  for (const id of rowTableIds) {
+    const table = tableById.get(id)!;
+    const { w, h } = estimateTableSize(table);
+
+    if (x > leftMargin && x + w > maxX) {
+      y += rowMaxH + V_GAP;
+      x = leftMargin;
+      rowMaxH = 0;
+    }
+
+    positions.set(id, { x, y });
+    rowMaxH = Math.max(rowMaxH, h);
+    maxRight = Math.max(maxRight, x + w);
+    x += w + H_GAP;
+  }
+
+  const nextY = y + rowMaxH;
+  return { positions, nextY, maxRight };
+}
+
+function layoutOneComponent(
+  comp: string[],
+  edges: Array<[string, string]>,
+  tableById: Map<string, Table>
+): { positions: Map<string, { x: number; y: number }>; width: number; height: number } {
+  const nodeSet = new Set(comp);
+  const adj = new Map<string, Set<string>>();
+  for (const id of comp) {
+    adj.set(id, new Set());
+  }
+  for (const [a, b] of edges) {
+    if (nodeSet.has(a) && nodeSet.has(b)) {
+      adj.get(a)?.add(b);
+      adj.get(b)?.add(a);
+    }
+  }
+
+  const root = [...comp].sort((x, y) =>
+    normalizeName(tableById.get(x)!).localeCompare(normalizeName(tableById.get(y)!))
+  )[0]!;
+  const layers = bfsLayers(root, adj, nodeSet);
+
+  const maxLayer = Math.max(0, ...layers.values());
+  const byLayer = new Map<number, string[]>();
+  for (let L = 0; L <= maxLayer; L++) {
+    byLayer.set(L, []);
+  }
+  for (const id of comp) {
+    const L = layers.get(id) ?? 0;
+    byLayer.get(L)?.push(id);
+  }
+  for (const ids of byLayer.values()) {
+    ids.sort((a, b) =>
+      normalizeName(tableById.get(a)!).localeCompare(normalizeName(tableById.get(b)!))
+    );
+  }
+
+  const positions = new Map<string, { x: number; y: number }>();
+  let localY = 0;
+  let maxRight = 0;
+
+  for (let L = 0; L <= maxLayer; L++) {
+    const row = byLayer.get(L) ?? [];
+    if (row.length === 0) continue;
+
+    const {
+      positions: rowPos,
+      nextY,
+      maxRight: layerRight,
+    } = placeLayerRowWrapped(row, localY, 0, tableById);
+    for (const [id, pos] of rowPos) {
+      positions.set(id, pos);
+    }
+    localY = nextY + V_GAP;
+    maxRight = Math.max(maxRight, layerRight);
+  }
+
+  let maxBottom = 0;
+  for (const [id, pos] of positions) {
+    const h = estimateTableSize(tableById.get(id)!).h;
+    maxBottom = Math.max(maxBottom, pos.y + h);
+  }
+
+  const height = maxBottom;
+  const width = maxRight;
+
+  return { positions, width, height };
+}
+
+/**
+ * Arranges tables using FK graph structure: connected components, BFS layers, wrapped rows,
+ * and packs component blocks in a 2D grid so edges are not stretched across the entire canvas width.
+ * Mutates table positions in place.
+ */
+export function applyAutoLayout(diagram: Diagram): void {
+  const tables = diagram.getAllTables();
+  if (tables.length === 0) return;
+
+  const tableById = new Map<string, Table>();
+  for (const t of tables) {
+    tableById.set(t.getId(), t);
+  }
+
+  const rels = diagram.getAllRelationships();
+  const edges: Array<[string, string]> = rels.map(r => [r.getFromTableId(), r.getToTableId()]);
+
+  const tableIds = tables.map(t => t.getId());
+  const components = getConnectedComponents(tableIds, edges);
+
+  components.sort((a, b) => {
+    const nameA = [...a].sort((x, y) =>
+      normalizeName(tableById.get(x)!).localeCompare(normalizeName(tableById.get(y)!))
+    )[0];
+    const nameB = [...b].sort((x, y) =>
+      normalizeName(tableById.get(x)!).localeCompare(normalizeName(tableById.get(y)!))
+    )[0];
+    return normalizeName(tableById.get(nameA!)!).localeCompare(
+      normalizeName(tableById.get(nameB!)!)
+    );
+  });
+
+  let blockLeft = MARGIN;
+  let blockTop = MARGIN;
+  let rowOfBlocksMaxHeight = 0;
+
+  for (const comp of components) {
+    const { positions, width, height } = layoutOneComponent(comp, edges, tableById);
+
+    if (blockLeft > MARGIN && blockLeft + width > MAX_COMPONENT_LINE_WIDTH) {
+      blockLeft = MARGIN;
+      blockTop += rowOfBlocksMaxHeight + COMPONENT_GAP;
+      rowOfBlocksMaxHeight = 0;
+    }
+
+    for (const [id, pos] of positions) {
+      tableById.get(id)!.moveTo({
+        x: pos.x + blockLeft,
+        y: pos.y + blockTop,
+      });
+    }
+
+    blockLeft += width + COMPONENT_GAP;
+    rowOfBlocksMaxHeight = Math.max(rowOfBlocksMaxHeight, height);
+  }
+}

--- a/src/client/core/exporter/FrontendExporter.ts
+++ b/src/client/core/exporter/FrontendExporter.ts
@@ -1,6 +1,33 @@
 import { Diagram } from '../diagram/Diagram';
 
 /**
+ * When every table has a rendered `.table-node`, use the same box as the canvas
+ * (offsetLeft/offsetTop + offsetWidth) so SVG routing matches RelationshipLine.tsx.
+ */
+function tryApplyDomBoxToSvgLayout(
+  diagramData: {
+    tables: Array<{ id: string; position: { x: number; y: number } }>;
+  },
+  tableWidthById: Map<string, number>,
+  minTableWidth: number
+): boolean {
+  if (typeof document === 'undefined') return false;
+  const byId = new Map<string, HTMLElement>();
+  for (const t of diagramData.tables) {
+    const el = document.querySelector(`.table-node[data-table-id="${t.id}"]`) as HTMLElement | null;
+    if (!el) return false;
+    byId.set(t.id, el);
+  }
+  for (const t of diagramData.tables) {
+    const el = byId.get(t.id)!;
+    t.position = { x: el.offsetLeft, y: el.offsetTop };
+    const w = el.offsetWidth;
+    tableWidthById.set(t.id, Math.max(minTableWidth, w > 0 ? w : minTableWidth));
+  }
+  return true;
+}
+
+/**
  * Frontend exporter interface
  */
 export interface FrontendExportResult {
@@ -130,6 +157,14 @@ export class FrontendExporter {
   exportSVG(diagram: Diagram): FrontendExportResult {
     try {
       const diagramData = diagram.toJSON();
+      // Always anchor layout to live Table positions (same as canvas), not a stale JSON view
+      for (const row of diagramData.tables) {
+        const live = diagram.getTable(row.id);
+        if (live) {
+          const p = live.getPosition();
+          row.position = { x: p.x, y: p.y };
+        }
+      }
       const padding = 50;
       const MIN_TABLE_WIDTH = 200;
       const TABLE_HEADER_HEIGHT_NO_DESC = 40;
@@ -141,6 +176,9 @@ export class FrontendExporter {
       const MARKER_MANY_OFFSET = 1;
       const MARKER_SIZE = 12;
       const HORIZONTAL_OFFSET = Math.max(40, MARKER_ONE_OFFSET + MARKER_SIZE + 15);
+      /** Match RelationshipLine.tsx — anchors sit just outside the table border */
+      const TABLE_EDGE_GAP_LEFT = 4;
+      const TABLE_EDGE_GAP_RIGHT = 6;
 
       // Text width approximation (Latin vs CJK/fullwidth — avoids comment overlap in SVG).
       const estimateTextWidth = (text: string, fontSize: number): number => {
@@ -266,6 +304,9 @@ export class FrontendExporter {
         tableWidthById.set(table.id, tableWidth);
       });
 
+      // Prefer painted layout in the browser so lines/widths match RelationshipLine (DOM measurement).
+      tryApplyDomBoxToSvgLayout(diagramData, tableWidthById, MIN_TABLE_WIDTH);
+
       // Calculate bounds
       let minX = Infinity;
       let minY = Infinity;
@@ -385,14 +426,20 @@ export class FrontendExporter {
         const toCenterX = toPos.x + toTableWidth / 2;
 
         const relationshipType = relationship.type;
-        const isFirstTable = (tableId: string) => tableId === 'table-1';
-        const isFromTableFirst = isFirstTable(fromTable.id);
-        const isToTableFirst = isFirstTable(toTable.id);
 
-        const getMarkerOffset = (isMany: boolean, isFirst: boolean) => {
-          if (isMany) return MARKER_MANY_OFFSET;
-          return isFirst ? MARKER_ONE_OFFSET + 10 : MARKER_ONE_OFFSET;
-        };
+        const markerOffsets = (() => {
+          if (relationshipType === 'ONE_TO_ONE') {
+            return { start: MARKER_ONE_OFFSET, end: MARKER_ONE_OFFSET };
+          }
+          if (relationshipType === 'ONE_TO_MANY') {
+            return { start: MARKER_MANY_OFFSET, end: MARKER_ONE_OFFSET };
+          }
+          if (relationshipType === 'MANY_TO_MANY') {
+            return { start: MARKER_MANY_OFFSET, end: MARKER_MANY_OFFSET };
+          }
+          return { start: MARKER_MANY_OFFSET, end: MARKER_ONE_OFFSET };
+        })();
+        const getMarkerOffset = (side: 'start' | 'end') => markerOffsets[side];
 
         let fromX: number;
         let toX: number;
@@ -403,43 +450,26 @@ export class FrontendExporter {
         let markerEndY: number;
         let startDirection: 'left' | 'right';
         let endDirection: 'left' | 'right';
-        let fromIsMany: boolean;
-        let toIsMany: boolean;
-
-        if (relationshipType === 'MANY_TO_MANY') {
-          fromIsMany = true;
-          toIsMany = true;
-        } else if (relationshipType === 'ONE_TO_ONE') {
-          fromIsMany = false;
-          toIsMany = false;
-        } else {
-          const fromColumnIsPk = fromColumn.constraints.some(c => c.type === 'PRIMARY_KEY');
-          const toColumnIsPk = toColumn.constraints.some(c => c.type === 'PRIMARY_KEY');
-          const fromColumnIsFk = fromColumn.constraints.some(c => c.type === 'FOREIGN_KEY');
-          const toColumnIsFk = toColumn.constraints.some(c => c.type === 'FOREIGN_KEY');
-          fromIsMany = fromColumnIsFk || (fromColumnIsPk ? false : true);
-          toIsMany = toColumnIsFk || (toColumnIsPk ? false : true);
-        }
 
         if (fromCenterX < toCenterX) {
-          fromX = fromRight;
-          toX = toLeft;
+          fromX = fromRight + TABLE_EDGE_GAP_RIGHT;
+          toX = toLeft - TABLE_EDGE_GAP_LEFT;
           const midX = fromX + HORIZONTAL_OFFSET;
           path = `M ${fromX} ${fromColumnY} L ${midX} ${fromColumnY} L ${midX} ${toColumnY} L ${toX} ${toColumnY}`;
-          markerStartX = fromX + getMarkerOffset(fromIsMany, isFromTableFirst);
+          markerStartX = fromX + getMarkerOffset('start');
           markerStartY = fromColumnY;
-          markerEndX = toX - getMarkerOffset(toIsMany, isToTableFirst);
+          markerEndX = toX - getMarkerOffset('end');
           markerEndY = toColumnY;
           startDirection = 'right';
           endDirection = 'left';
         } else {
-          fromX = fromLeft;
-          toX = toRight;
+          fromX = fromLeft - TABLE_EDGE_GAP_LEFT;
+          toX = toRight + TABLE_EDGE_GAP_RIGHT;
           const midX = fromX - HORIZONTAL_OFFSET;
           path = `M ${fromX} ${fromColumnY} L ${midX} ${fromColumnY} L ${midX} ${toColumnY} L ${toX} ${toColumnY}`;
-          markerStartX = fromX - getMarkerOffset(fromIsMany, isFromTableFirst);
+          markerStartX = fromX - getMarkerOffset('start');
           markerStartY = fromColumnY;
-          markerEndX = toX + getMarkerOffset(toIsMany, isToTableFirst);
+          markerEndX = toX + getMarkerOffset('end');
           markerEndY = toColumnY;
           startDirection = 'left';
           endDirection = 'right';


### PR DESCRIPTION
## Summary
- Align **SVG export** with the live canvas: when `.table-node` elements exist, use **DOM** `offsetLeft` / `offsetTop` and `offsetWidth` (same idea as `RelationshipLine`), with **double `requestAnimationFrame`** before export so layout is painted.
- **FrontendExporter** relationship geometry stays aligned with canvas markers/gaps.
- **DiagramCanvas**: refresh diagram from JSON after table drag end so the store matches rendered positions.
- **RelationshipLine**: header height for routing matches tables with table description.
- Includes **auto layout** and related diagram/render fixes from this branch.

## Testing
- `npm run type-check`, `npm run lint`, `npm run format:check`, `npm run build`, `npm run test` (via `scripts/push_git.sh`).

