### PR TITLE
fix: auto layout on first Draw from editor; skip on later Draws (issu…

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -18,6 +18,7 @@ import { ApiClient } from './services/ApiClient';
 import { DiagramValidator } from './core/validator/DiagramValidator';
 import { Diagram } from './core/diagram/Diagram';
 import { mergeDiagramLayout } from './core/diagram/mergeDiagramLayout';
+import { applyAutoLayout } from './core/diagram/autoLayoutDiagram';
 import { Table } from './core/table/Table';
 import { Relationship } from './core/relationship/Relationship';
 import { Column } from './types/table.types';
@@ -72,7 +73,11 @@ function App() {
     try {
       const newDiagram = Diagram.create(`diagram-${Date.now()}`);
       diagramStore.setDiagram(newDiagram);
-      uiStore.setState({ selectedTableId: null, selectedRelationshipId: null });
+      uiStore.setState({
+        selectedTableId: null,
+        selectedRelationshipId: null,
+        editorDrawAutoLayoutPending: true,
+      });
       setError(null);
       setImportText(undefined); // Clear import text so editor is cleared
       showNotification('success', 'New diagram created');
@@ -83,8 +88,12 @@ function App() {
     }
   }, [showNotification]);
 
-  const handleDiagramLoaded = useCallback(() => {
-    uiStore.setState({ selectedTableId: null, selectedRelationshipId: null });
+  const handleDiagramLoaded = useCallback((source: 'import' | 'load') => {
+    uiStore.setState({
+      selectedTableId: null,
+      selectedRelationshipId: null,
+      editorDrawAutoLayoutPending: source === 'import',
+    });
     setError(null);
   }, []);
 
@@ -247,7 +256,16 @@ function App() {
   const handleDiagramChangeFromSQL = useCallback(
     (newDiagram: Diagram) => {
       const previous = diagramStore.getDiagram();
-      diagramStore.setDiagram(mergeDiagramLayout(previous, newDiagram));
+      const merged = mergeDiagramLayout(previous, newDiagram);
+      let next = merged;
+      const pending = uiStore.getState().editorDrawAutoLayoutPending;
+      if (pending && merged.getAllTables().length > 0) {
+        const laidOut = Diagram.fromJSON(merged.toJSON());
+        applyAutoLayout(laidOut);
+        next = laidOut;
+        uiStore.setState({ editorDrawAutoLayoutPending: false });
+      }
+      diagramStore.setDiagram(next);
       setError(null);
     },
     [diagramStore]

--- a/src/client/components/Toolbar/Toolbar.tsx
+++ b/src/client/components/Toolbar/Toolbar.tsx
@@ -15,7 +15,8 @@ interface ToolbarProps {
   exportService: ExportService;
   diagramStore: DiagramStore;
   onNewDiagram: () => void;
-  onDiagramLoaded: () => void;
+  /** Call after diagram replaced from Import (pending first Draw layout) or Load (keep saved positions). */
+  onDiagramLoaded: (source: 'import' | 'load') => void;
   onImportText?: (text: string) => void; // Callback to set text in editor
   onGetEditorText?: () => string | undefined; // Callback to get current editor text
   onGetEditorFormat?: () => 'sql' | 'dbml' | undefined; // Callback to get current editor format
@@ -97,7 +98,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     const relationshipsAfter = diagramAfter?.getAllRelationships() || [];
     console.log(`🔍 After setDiagram: ${relationshipsAfter.length} relationships`);
 
-    onDiagramLoaded();
+    onDiagramLoaded('import');
     // Set text in editor if provided
     if (importText && onImportText) {
       onImportText(importText);
@@ -171,7 +172,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
         isOpen={showLoadDialog}
         onClose={() => setShowLoadDialog(false)}
         onLoad={diagramText => {
-          onDiagramLoaded();
+          onDiagramLoaded('load');
           // Set text in editor if provided
           if (diagramText && onImportText) {
             onImportText(diagramText);

--- a/src/client/state/store/uiStore.ts
+++ b/src/client/state/store/uiStore.ts
@@ -10,6 +10,11 @@ export interface UIState {
   showSidebar: boolean;
   /** When true, the SQL/DBML editor panel is collapsed to a narrow strip */
   editorPanelCollapsed: boolean;
+  /**
+   * When true, the next successful Draw from the schema editor runs auto layout after merge.
+   * Set false after that draw; reset on New / Import. Cleared when loading a saved diagram (positions preserved).
+   */
+  editorDrawAutoLayoutPending: boolean;
 }
 
 /**
@@ -34,6 +39,7 @@ export class UIStore {
     showGrid: true,
     showSidebar: true,
     editorPanelCollapsed: false,
+    editorDrawAutoLayoutPending: true,
   };
 
   private observers: Array<Observer<UIState>> = [];


### PR DESCRIPTION
## Summary
Fixes the behavior where **auto layout did not run on the first Draw** after pasting SQL/DBML. The first successful **Draw** from the schema editor now applies **`applyAutoLayout`** after `mergeDiagramLayout`. Later Draws only merge and **keep user-adjusted table positions**.

## Behavior
| Situation | Auto layout on next Draw |
|-----------|---------------------------|
| First Draw in session (or after **New** / **Import**) when diagram has tables | Yes (once), then flag cleared |
| Later Draws | No — merge by table name only |
| **Load** saved diagram | No auto layout on Draw — keeps stored positions |

## Implementation
- **`UIStore`**: `editorDrawAutoLayoutPending` (default `true`).
- **`App.handleDiagramChangeFromSQL`**: if pending and merged diagram has tables → clone, `applyAutoLayout`, set pending `false`.
- **`handleNewDiagram`**: reset pending `true`.
- **`handleDiagramLoaded('import' | 'load')`**: import → pending `true`; load → pending `false`.
- **`Toolbar`**: passes `onDiagramLoaded('import')` / `onDiagramLoaded('load')` accordingly.

## Testing
- `npm run type-check`, `npm run lint`, `npm run format:check`, `npm run build`, `npm run test` (via `scripts/push_git.sh`).

## Related
- Closes / addresses issue: **#1** (first Draw auto layout).