### PR TITLE
fix: ignore file picker cancel in save/load/import flows

### DIFF
--- a/src/client/components/ImportDialog/ImportDialog.tsx
+++ b/src/client/components/ImportDialog/ImportDialog.tsx
@@ -2,7 +2,11 @@ import { useState, useEffect } from 'react';
 import { JSONParser } from '../../core/parser/JSONParser';
 import { SQLParser } from '../../core/parser/SQLParser';
 import { Diagram } from '../../core/diagram/Diagram';
-import { FilePickerAccept, pickTextFile } from '../../utils/fileSystemAccess';
+import {
+  FilePickerAccept,
+  isUserCancelledFilePickerError,
+  pickTextFile,
+} from '../../utils/fileSystemAccess';
 import './ImportDialog.css';
 
 interface ImportDialogProps {
@@ -68,6 +72,9 @@ export const ImportDialog: React.FC<ImportDialogProps> = ({ isOpen, onClose, onI
         return;
       }
     } catch (err) {
+      if (isUserCancelledFilePickerError(err)) {
+        return;
+      }
       setError(err instanceof Error ? err.message : 'Failed to read file');
     }
   };

--- a/src/client/components/Toolbar/Toolbar.tsx
+++ b/src/client/components/Toolbar/Toolbar.tsx
@@ -8,7 +8,12 @@ import { JSONParser } from '../../core/parser/JSONParser';
 import { ImportDialog } from '../ImportDialog/ImportDialog';
 import { ExportDialog } from '../ExportDialog/ExportDialog';
 import { KeyboardShortcutsHelp } from '../KeyboardShortcutsHelp/KeyboardShortcutsHelp';
-import { FilePickerAccept, pickTextFile, saveTextFile } from '../../utils/fileSystemAccess';
+import {
+  FilePickerAccept,
+  isUserCancelledFilePickerError,
+  pickTextFile,
+  saveTextFile,
+} from '../../utils/fileSystemAccess';
 import './Toolbar.css';
 
 interface ToolbarProps {
@@ -80,6 +85,9 @@ export const Toolbar: React.FC<ToolbarProps> = ({
       });
       alert('Diagram saved to file successfully!');
     } catch (error) {
+      if (isUserCancelledFilePickerError(error)) {
+        return;
+      }
       alert(`Error saving diagram: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   };
@@ -114,6 +122,9 @@ export const Toolbar: React.FC<ToolbarProps> = ({
       }
       alert('Diagram loaded from file successfully!');
     } catch (error) {
+      if (isUserCancelledFilePickerError(error)) {
+        return;
+      }
       alert(`Error loading diagram: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   };

--- a/src/client/utils/fileSystemAccess.ts
+++ b/src/client/utils/fileSystemAccess.ts
@@ -44,6 +44,20 @@ export interface FilePickerAccept {
   extensions: string[];
 }
 
+export class UserCancelledFilePickerError extends Error {
+  constructor() {
+    super('User cancelled file picker');
+    this.name = 'UserCancelledFilePickerError';
+  }
+}
+
+export function isUserCancelledFilePickerError(error: unknown): boolean {
+  if (error instanceof UserCancelledFilePickerError) return true;
+  if (error instanceof DOMException && error.name === 'AbortError') return true;
+  if (error instanceof Error && error.name === 'AbortError') return true;
+  return false;
+}
+
 export function supportsFileSystemAccessApi(): boolean {
   const w = window as WindowFilePickerSupport;
   return typeof w.showOpenFilePicker === 'function' && typeof w.showSaveFilePicker === 'function';
@@ -76,15 +90,32 @@ function readFromInputElement(accept?: FilePickerAccept[]): Promise<File> {
     const input = document.createElement('input');
     input.type = 'file';
     input.accept = accept?.flatMap(item => item.extensions).join(',') || '';
+    let handled = false;
     input.onchange = () => {
+      handled = true;
       const file = input.files?.[0];
       if (!file) {
-        reject(new Error('No file selected'));
+        reject(new UserCancelledFilePickerError());
         return;
       }
       resolve(file);
     };
     input.onerror = () => reject(new Error('Failed to open file picker'));
+    input.oncancel = () => {
+      handled = true;
+      reject(new UserCancelledFilePickerError());
+    };
+
+    const onFocusBack = () => {
+      setTimeout(() => {
+        if (!handled) {
+          handled = true;
+          reject(new UserCancelledFilePickerError());
+        }
+        window.removeEventListener('focus', onFocusBack, true);
+      }, 0);
+    };
+    window.addEventListener('focus', onFocusBack, true);
     input.click();
   });
 }


### PR DESCRIPTION
## Summary
Fixes UX bug in `main-frontendonly` where cancelling the browser file picker was treated as an error.

Now, when users click **Cancel** in file dialogs for:
- **Save**
- **Load**
- **Import from File**

the app silently aborts the action instead of showing error alerts/messages.

## What changed
- Added explicit cancel-aware handling in shared file-access utility:
  - `UserCancelledFilePickerError`
  - `isUserCancelledFilePickerError(...)`
- Updated fallback `<input type="file">` flow to emit cancellation as a dedicated cancel signal.
- Updated action handlers to ignore cancel path:
  - `Toolbar` (Save / Load)
  - `ImportDialog` (Import from File)

## Files
- `src/client/utils/fileSystemAccess.ts`
- `src/client/components/Toolbar/Toolbar.tsx`
- `src/client/components/ImportDialog/ImportDialog.tsx`

## Why
Cancelling a picker is a normal user action, not a runtime failure.  
This change prevents false error noise and improves UX for frontend-only file workflows.

## Test plan
- `npm run type-check`
- `npm run build`
- `npm run test`

Manual:
1. Click **Save** → file dialog opens → **Cancel** → no error.
2. Click **Load** → file dialog opens → **Cancel** → no error.
3. Click **Import** → **From File** → **Cancel** → no error.
4. Real errors (invalid file/parse/permission denied) still show error handling as expected.

## Notes
- No backend behavior affected.
- Existing lint warnings unrelated to this fix remain unchanged.